### PR TITLE
Fixes an Issue where agents were not properly leaving chat channels after Transfers

### DIFF
--- a/src/ChatTransferPlugin.js
+++ b/src/ChatTransferPlugin.js
@@ -1,52 +1,9 @@
 import { FlexPlugin } from 'flex-plugin';
-import fetch from 'node-fetch';
-import React from 'react';
-import * as Flex from '@twilio/flex-ui';
-import TransferButton from './components/TransferButton';
+import { setUpActions } from './helpers/actions';
+import { setUpComponents } from './helpers/components';
+import { setUpNotifications } from './helpers/notifications';
 
 const PLUGIN_NAME = 'ChatTransferPlugin';
-const DEFAULT_TRANSFER_MODE = 'COLD';
-const SERVERLESS_FUNCTION_DOMAIN = '';
-
-export const setUpComponents = () => {
-	Flex.TaskCanvasHeader.Content.add(<TransferButton key="chat-transfer-button" />, {
-		sortOrder: 1,
-		if: (props) =>
-			props.channelDefinition.capabilities.has('Chat') && props.task.taskStatus === 'assigned',
-	});
-};
-
-export const setUpActions = () => {
-	Flex.Actions.replaceAction('TransferTask', (payload, original) =>
-		transferOverride(payload, original)
-	);
-};
-
-export const transferOverride = (payload, original) => {
-	if (!Flex.TaskHelper.isChatBasedTask(payload.task)) {
-		return original(payload);
-	}
-
-	const mode = payload.options.mode || DEFAULT_TRANSFER_MODE;
-
-
-  const manager = Flex.Manager.getInstance();
-  const body = {
-    Token: manager.user.token,
-    mode: mode,
-    taskSid: payload.task.taskSid,
-    targetSid: payload.targetSid,
-    workerName: manager.user.identity,
-  };
-
-  return fetch(`https://${SERVERLESS_FUNCTION_DOMAIN}/transfer-chat`, {
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    method: 'POST',
-    body: JSON.stringify(body),
-  })
-};
 
 export default class ChatTransferPlugin extends FlexPlugin {
 	constructor() {
@@ -62,6 +19,7 @@ export default class ChatTransferPlugin extends FlexPlugin {
 	 */
 	init(flex, manager) {
 		setUpComponents();
+		setUpNotifications();
 		setUpActions();
 	}
 }

--- a/src/helpers/actions.js
+++ b/src/helpers/actions.js
@@ -1,0 +1,89 @@
+import { Actions, ChatOrchestrator, TaskHelper, Manager, Notifications } from '@twilio/flex-ui';
+import fetch from 'node-fetch';
+
+const DEFAULT_TRANSFER_MODE = 'COLD';
+// Once you publish the chat transfer function, place the returned domain in your version of the plugin.
+const SERVERLESS_FUNCTION_DOMAIN = '';
+
+/**
+ * This replaces Flex's default TransferTask action with our own implementation.
+ * The great thing about replacing Flex actions is that you get access to the original action,
+ * so you can still call it in certain scenarios. In this case, we only want to run our `transferOverride`
+ * function if the task is a chat-like task.
+ *
+ * If its a voice task, we want to run the original function. (see transferOverride for details)
+ */
+export const setUpActions = () => {
+	Actions.replaceAction('TransferTask', (payload, original) => transferOverride(payload, original));
+	// Modify default Flex Orchestrations for Chat Channels
+	ChatOrchestrator.setOrchestrations('wrapup', orchestrationCallback);
+	ChatOrchestrator.setOrchestrations('completed', orchestrationCallback);
+};
+
+/**
+ * Every task that enters wrapup, or completed states runs through this callback. (see setUpActions)
+ *
+ * By default, when you push a chat task into wrapping, flex deactivates the chat channel and removes the
+ * agent from the chat. In the case of a transfer and completion of the original task, we don't want to do this.
+ *
+ * The callback inspects the task for a specific attribute `wasTransferred` - this attribute
+ * is added during the request to initiate the transfer. If we see it, we modify which orchestrations run.
+ *
+ * In this case, if we see the task is a transferred task, we only want to run the LeaveChatChannel orchestration.
+ * Returning 'LeaveChatChannel' only - allows the agent to leave the conversation without closing the chat session
+ * Returning 'DeactivateChatChannel' and 'LeaveChatChannel' closes the channel when the agent leaves.
+ */
+export const orchestrationCallback = (task) => {
+	if (task.attributes.wasTransferred) {
+		return ['LeaveChatChannel'];
+	}
+	return ['DeactivateChatChannel', 'LeaveChatChannel'];
+};
+
+/**
+ * This is the function we replaced Flex's default TransferTask action with.
+ *
+ * First, it inspects the task passing through it, if the task is not chat-based it calls the original
+ * Flex TransferTask action. This allows voice transfers to complete as normal.
+ *
+ * Assuming its a chat task, we initiate a request to our serverless function to iniate the transfer.
+ */
+export const transferOverride = async (payload, original) => {
+	if (!TaskHelper.isChatBasedTask(payload.task)) {
+		return original(payload);
+	}
+
+	// set a flag on the task attributes to let us know its a transfer task
+	// this is what tells the ChatOrchestrator to do when this task is put into
+	// wrapping or completed - see orchestrationCallback
+	const { attributes } = payload.task;
+	attributes.wasTransferred = true;
+	await payload.task.setAttributes(attributes);
+
+	// We can support both warm and cold transfer options
+	const mode = payload.options.mode || DEFAULT_TRANSFER_MODE;
+
+	// instantiate the manager to get useful info like user identity and token
+	// build the request to initiate the transfer
+	const manager = Manager.getInstance();
+	const body = {
+		Token: manager.user.token,
+		mode: mode,
+		taskSid: payload.task.taskSid,
+		targetSid: payload.targetSid,
+		workerName: manager.user.identity,
+	};
+
+	// initiate the transfer
+	return fetch(`http://${SERVERLESS_FUNCTION_DOMAIN}/transfer-chat`, {
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		method: 'POST',
+		body: JSON.stringify(body),
+	}).catch((e) => {
+		// see src/helpers/notifications.js for how this custom notification is registered.
+		// if for some reason the request to transfer fails, show it to the agent
+		Notifications.showNotification('chatTransferFetchError', { message: e.message });
+	});
+};

--- a/src/helpers/components.js
+++ b/src/helpers/components.js
@@ -1,0 +1,17 @@
+import * as Flex from '@twilio/flex-ui';
+import React from 'react';
+import TransferButton from '../components/TransferButton';
+
+/**
+ * This appends new content to the Chat Canvas (adds transfer button near end chat button)
+ *
+ * The if: property here is important, this says only add the transfer button if this is chat-like task
+ * and the task has been assigned.
+ */
+export const setUpComponents = () => {
+	Flex.TaskCanvasHeader.Content.add(<TransferButton key="chat-transfer-button" />, {
+		sortOrder: 1,
+		if: (props) =>
+			props.channelDefinition.capabilities.has('Chat') && props.task.taskStatus === 'assigned',
+	});
+};

--- a/src/helpers/notifications.js
+++ b/src/helpers/notifications.js
@@ -1,0 +1,20 @@
+import { Manager, Notifications, NotificationType } from '@twilio/flex-ui';
+
+/**
+ * Sets up a custom notification that can be invoked if the request to transfer the
+ * chat task, fails for some reason. Notice we define this as a template on the Manager instance,
+ * this means that we can pass in context when we invoke the notification (such as the http error message)
+ * and it will replace the {{message}} token.
+ *
+ * see actions.js (transferOverride function) for an example of how the notification is invoked
+ */
+export const setUpNotifications = () => {
+	const manager = Manager.getInstance();
+	manager.strings.chatTransferFetchErrorTemplate = 'Failed: {{message}}';
+
+	Notifications.registerNotification({
+		id: 'chatTransferFetchError',
+		content: 'chatTransferFetchErrorTemplate',
+		type: NotificationType.error,
+	});
+};


### PR DESCRIPTION
Previous versions of this plugin used a bit of a hacky move with Task attributes to force the Flex Chat Orchestration service to ignore deactivating chat channels during transfers. It did this by setting dummy values for channelSid and proxySessionId in the `transfer-chat.js` function. 

This approach had an unfortunate side affect that it also never removed the agent from the chat session. Eventually the chat service stops the agent from joining anymore channels because they were never leaving any of the previous channels they joined.

This refactor completely removes that approach and uses the proper `ChatOrchestrator` object in Flex. This object controls whether or not to deactivate the chat channel and/or remove the agent from the channel. This is important because by default when an agent pushes a task to wrapping - the chat channel gets marked as inactive and the chat ends. 

During the transfer flow we don't want this to happen. The chat should remain active until the final agent completes the task. We now fully support this use-case.

Additionally, I took the time to document the code in the plugin to a greater degree.